### PR TITLE
Add in-line style to the Link component

### DIFF
--- a/src/components/ParkCards/ParkCards.tsx
+++ b/src/components/ParkCards/ParkCards.tsx
@@ -15,7 +15,7 @@ function ParkCards({ park }: { park: ParkProps }) {
   }
 
   return (
-    <Link to={`/park/${park.parkCode}`} style={{ textDecoration: 'none' }}> 
+    <Link to={`/park/${park.parkCode}`} style={{ textDecoration: 'inherit' }}> 
       <div className='park-card'>
         <h3>{park.fullName}</h3>
         <div className="image-gallery">

--- a/src/components/ParkCards/ParkCards.tsx
+++ b/src/components/ParkCards/ParkCards.tsx
@@ -15,7 +15,7 @@ function ParkCards({ park }: { park: ParkProps }) {
   }
 
   return (
-    <Link to={`/park/${park.parkCode}`}> 
+    <Link to={`/park/${park.parkCode}`} style={{ textDecoration: 'none' }}> 
       <div className='park-card'>
         <h3>{park.fullName}</h3>
         <div className="image-gallery">


### PR DESCRIPTION
## PR Details

### What does this PR do?
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Other:

**Explain briefly:**
I added an in-line style to the link component to remove the default underline style. 
I referenced [this stack overflow thread ](https://stackoverflow.com/questions/37669391/how-to-get-rid-of-underline-for-link-component-of-react-router)on the differenet ways to do it.

Initially I added an in-line style like this :   

```<Link to={`/park/${park.parkCode}`} style={{ textDecoration: 'none' }}> ```

  I decided to change the value of textDecoration from `none` to `inherit` to allow for future styling.  

```textDecoration: inherit```
-   ^ this means the text within the Link will inherit the styling from the parent.  

```textDecoration: 'none' ```
-  ^ this explicitly removes any text decoration from the link, ensuring that it is not underlined or decorated in any way.
---

### Does it break anything?
- [x] No
- [ ] Yes (describe: )

---

### Checklist
- [ ] Code runs locally
- [ ] All tests pass
- [ ] Code is DRY / comments added where needed

---

### What's next?
